### PR TITLE
Loosen rack constraint

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,10 @@
 PATH
   remote: .
   specs:
-    http_client_detector (0.0.1)
+    http_client_detector (0.2.2)
       json (~> 1.7)
-      rack (= 1.4.5)
-      rack-contrib (= 1.1.0)
+      rack (~> 1.4)
+      rack-contrib (~> 1.2.0)
       rest-client (= 1.6.7)
 
 GEM
@@ -14,10 +14,10 @@ GEM
     crack (0.4.1)
       safe_yaml (~> 0.9.0)
     diff-lcs (1.2.5)
-    json (1.8.1)
+    json (1.8.3)
     mime-types (1.25.1)
-    rack (1.4.5)
-    rack-contrib (1.1.0)
+    rack (1.6.4)
+    rack-contrib (1.2.0)
       rack (>= 0.9.1)
     rack-test (0.6.2)
       rack (>= 1.0)
@@ -47,3 +47,6 @@ DEPENDENCIES
   rake (= 0.8.7)
   rspec (~> 2.14)
   webmock (~> 1.13)
+
+BUNDLED WITH
+   1.10.6

--- a/README.md
+++ b/README.md
@@ -9,6 +9,15 @@ A Rack middleware that detects the caracteristics of http client, taking into ac
   rspec
 ```
 
+## Docker Setup
+```bash
+  git clone https://github.com/experteer/http_client_detector.git
+  docker run -it -v $PWD/http_client_detector:/home/default/http_client_detector admin.experteer.com:5000/experteer/ruby bash
+  cd http_client_detector/
+  bundle
+  rspec
+```
+
 ### Setup in your app
 
 add to Gemfile:

--- a/http_client_detector.gemspec
+++ b/http_client_detector.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'http_client_detector'
-  s.version = '0.2.1'
+  s.version = '0.2.2'
 
   s.required_rubygems_version = Gem::Requirement.new('>= 0') if s.respond_to? :required_rubygems_version=
   s.authors = ['Taras Struk']

--- a/http_client_detector.gemspec
+++ b/http_client_detector.gemspec
@@ -24,16 +24,16 @@ Gem::Specification.new do |s|
 
   s.specification_version = 3
 
-  s.add_runtime_dependency(%q<rack>, ['1.4.5'])
-  s.add_runtime_dependency(%q<rack-contrib>, ['1.1.0'])
-  s.add_runtime_dependency(%q<rest-client>, ['1.6.7'])
-  s.add_runtime_dependency(%q<json>, ['~> 1.7'])
+  s.add_runtime_dependency "rack", "1.4.5"
+  s.add_runtime_dependency "rack-contrib", "1.1.0"
+  s.add_runtime_dependency "rest-client", "1.6.7"
+  s.add_runtime_dependency "json", "~> 1.7"
 
-  s.add_development_dependency(%q<rake>, ['0.8.7'])
-  s.add_development_dependency(%q<rack-test>, ['~> 0.6'])
-  s.add_development_dependency(%q<rspec>, ['~> 2.14'])
-  s.add_development_dependency(%q<mime-types>, ['~> 1.25'])
-  s.add_development_dependency(%q<webmock>, ['~> 1.13'])
+  s.add_development_dependency "rake", "0.8.7"
+  s.add_development_dependency "rack-test", "~> 0.6"
+  s.add_development_dependency "rspec", "~> 2.14"
+  s.add_development_dependency "mime-types", "~> 1.25"
+  s.add_development_dependency "webmock", "~> 1.13"
 
 
 end

--- a/http_client_detector.gemspec
+++ b/http_client_detector.gemspec
@@ -24,8 +24,8 @@ Gem::Specification.new do |s|
 
   s.specification_version = 3
 
-  s.add_runtime_dependency "rack", "1.4.5"
-  s.add_runtime_dependency "rack-contrib", "1.1.0"
+  s.add_runtime_dependency "rack", "~> 1.4"
+  s.add_runtime_dependency "rack-contrib", "~> 1.2.0"
   s.add_runtime_dependency "rest-client", "1.6.7"
   s.add_runtime_dependency "json", "~> 1.7"
 

--- a/http_client_detector.gemspec
+++ b/http_client_detector.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'http_client_detector'
-  s.version = '0.2.0'
+  s.version = '0.2.1'
 
   s.required_rubygems_version = Gem::Requirement.new('>= 0') if s.respond_to? :required_rubygems_version=
   s.authors = ['Taras Struk']

--- a/lib/http_client_detector.rb
+++ b/lib/http_client_detector.rb
@@ -2,6 +2,7 @@ require "#{File.dirname(__FILE__)}/http_client_info"
 require 'cgi'
 require 'json'
 require 'logger'
+require 'rest_client'
 require 'rack/contrib/cookies'
 
 class HttpClientDetector


### PR DESCRIPTION
- First "back-ported" what's currently installed (0.2.1) in pjpp (diffing the files yields no difference now)
- Then raised the rack version so we can use this with Rails 4

All tests still pass and I can't see anything in the code that would break with a different version of Rack.

If that is good, please merge and publish the new version.
