### PR TITLE
Drop the dependency on rest-client

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,10 @@
 PATH
   remote: .
   specs:
-    http_client_detector (0.3.0)
+    http_client_detector (0.3.1)
       json (~> 1.7)
       rack (>= 1.4)
       rack-contrib (~> 1.2.0)
-      rest-client (= 1.8.0)
 
 GEM
   remote: http://rubygems.org/
@@ -16,15 +15,10 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
-    domain_name (0.5.20170404)
-      unf (>= 0.0.5, < 1.0.0)
     hashdiff (0.3.7)
-    http-cookie (1.0.3)
-      domain_name (~> 0.5)
     json (1.8.6)
     method_source (0.9.0)
     mime-types (2.99.3)
-    netrc (0.11.0)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -35,10 +29,6 @@ GEM
     rack-test (1.0.0)
       rack (>= 1.0, < 3)
     rake (12.3.1)
-    rest-client (1.8.0)
-      http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 3.0)
-      netrc (~> 0.7)
     rspec (3.7.0)
       rspec-core (~> 3.7.0)
       rspec-expectations (~> 3.7.0)
@@ -53,9 +43,6 @@ GEM
       rspec-support (~> 3.7.0)
     rspec-support (3.7.1)
     safe_yaml (1.0.4)
-    unf (0.1.4)
-      unf_ext
-    unf_ext (0.0.7.5)
     webmock (3.3.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -74,4 +61,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.16.1
+   1.17.1

--- a/http_client_detector.gemspec
+++ b/http_client_detector.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'http_client_detector'
-  s.version = '0.3.0'
+  s.version = '0.3.1'
 
   s.required_rubygems_version = Gem::Requirement.new('>= 0') if s.respond_to? :required_rubygems_version=
   s.authors = ['Taras Struk']
@@ -26,7 +26,6 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency "rack", ">= 1.4"
   s.add_runtime_dependency "rack-contrib", "~> 1.2.0"
-  s.add_runtime_dependency "rest-client", "1.8.0"
   s.add_runtime_dependency "json", "~> 1.7"
 
   s.add_development_dependency "rake"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,6 @@ ENV['RACK_ENV'] = 'test'
 require 'rack/test'
 require 'json'
 require 'cgi'
-require 'rest_client'
 require 'webmock/rspec'
 require 'pry'
 


### PR DESCRIPTION
We need to loosen the requirements on rest-client in order to be able to
update mail in pjpp. rest-client 1.x has a constraint of < 3.0 on
mime-types which makes it impossible to use a recent version of
google-api-client.